### PR TITLE
Suppress "array offset on null" warning in compile.php

### DIFF
--- a/compile.php
+++ b/compile.php
@@ -287,7 +287,7 @@ function php_shrink($input) {
 		if (!is_array($token)) {
 			$token = array(0, $token);
 		}
-		if ($tokens[$i+2][0] === T_CLOSE_TAG && $tokens[$i+3][0] === T_INLINE_HTML && $tokens[$i+4][0] === T_OPEN_TAG
+		if (isset($tokens[$i+4]) && $tokens[$i+2][0] === T_CLOSE_TAG && $tokens[$i+3][0] === T_INLINE_HTML && $tokens[$i+4][0] === T_OPEN_TAG
 			&& strlen(add_apo_slashes($tokens[$i+3][1])) < strlen($tokens[$i+3][1]) + 3
 		) {
 			$tokens[$i+2] = array(T_ECHO, 'echo');


### PR DESCRIPTION
In **Version 4** I am seeing this when running `php compile.php mysql en` :

`PHP Warning: Trying to access array offset on null in /adminerneo/compile.php on line 290`

The same command in **Version 5** (path `bin/compile.php`) works as expected.

Looking at the difference between `main` and `version-5` around this section of the code: there is an `isset()` check:

**main:**
```php
if ($tokens[$i+2][0] === T_CLOSE_TAG && $tokens[$i+3][0] === T_INLINE_HTML && $tokens[$i+4][0] === T_OPEN_TAG
```
**version-5:**
```php
if (isset($tokens[$i+4]) && $tokens[$i+2][0] === T_CLOSE_TAG && $tokens[$i+3][0] === T_INLINE_HTML && $tokens[$i+4][0] === T_OPEN_TAG
```
Adding this same `isset()` check to **Version 4** appears to fix this issue. Thanks.