### PR TITLE
comment out "check function definition in drivers" in compile.php

### DIFF
--- a/compile.php
+++ b/compile.php
@@ -415,6 +415,7 @@ if ($argv) {
 }
 
 // Check function definition in drivers.
+/* Disabled for now because it reports too many warnings.
 $file = file_get_contents(dirname(__FILE__) . "/adminer/drivers/mysql.inc.php");
 $file = preg_replace('~class Min_Driver.*\n\t}~sU', '', $file);
 preg_match_all('~\bfunction ([^(]+)~', $file, $matches); //! respect context (extension, class)
@@ -435,6 +436,7 @@ foreach (glob(dirname(__FILE__) . "/adminer/drivers/*.inc.php") as $filename) {
 		}
 	}
 }
+*/
 
 include dirname(__FILE__) . "/adminer/include/pdo.inc.php";
 include dirname(__FILE__) . "/adminer/include/driver.inc.php";


### PR DESCRIPTION
When compiling **Version 4** (on PHP **8.4**) with no drivers/langs passed as arguments, the compile succeeds but throws a bunch of this to STDOUT:
```
Missing function result in /adminerneo/adminer/drivers/mongo.inc.php
Missing function multi_query in /adminerneo/adminer/drivers/mongo.inc.php
Missing function store_result in /adminerneo/adminer/drivers/mongo.inc.php
Missing function next_result in /adminerneo/adminer/drivers/mongo.inc.php
Missing function limit in /adminerneo/adminer/drivers/mongo.inc.php
Missing function limit1 in /adminerneo/adminer/drivers/mongo.inc.php
Missing function view in /adminerneo/adminer/drivers/mongo.inc.php
Missing function rename_database in /adminerneo/adminer/drivers/mongo.inc.php
Missing function auto_increment in /adminerneo/adminer/drivers/mongo.inc.php
Missing function drop_views in /adminerneo/adminer/drivers/mongo.inc.php
```
In fact some of these `Missing function` errors happen when passing any driver other than **mysql**.
Again, the compile still works despite these errors.

It appears that this entire block of code was commented out from **/adminerneo/bin/compile.php** in **Version** 5 in 43c1ecb3152dc42b0e18c3b442db30baab45d9d4.
This PR simply comments out the same block of code in **/adminerneo/compile.php** in **Version 4**.

All compiles (all drivers/langs, or none at all) working fine. Thanks.