### PR TITLE
Fix links to MySQL docs

### DIFF
--- a/adminer/static/editing.js
+++ b/adminer/static/editing.js
@@ -30,7 +30,7 @@ function bodyLoad(version, maria) {
 				}
 
 				obj[key] = (maria ? obj[key].replace('dev.mysql.com/doc/mysql/en/', 'mariadb.com/kb/en/') : obj[key]) // MariaDB
-					.replace('/doc/mysql/', '/doc/refman/' + version) // MySQL
+					.replace('/doc/mysql/', '/doc/refman/' + version + '/') // MySQL
 					.replace('/docs/current/', '/docs/' + version) // PostgreSQL
 				;
 			}


### PR DESCRIPTION
It was directing to https://dev.mysql.com/doc/refman/9.2en/select.html instead of https://dev.mysql.com/doc/refman/9.2/en/select.html