### PR TITLE
Suppress "array offset on null" warning when selecting rows on table with FULLTEXT index (Search box)

### DIFF
--- a/adminer/core/Adminer.php
+++ b/adminer/core/Adminer.php
@@ -480,7 +480,7 @@ class Adminer extends AdminerBase
 		foreach ($indexes as $i => $index) {
 			if ($index["type"] == "FULLTEXT") {
 				echo "<div>(<i>" . implode("</i>, <i>", array_map('Adminer\h', $index["columns"])) . "</i>) AGAINST";
-				echo "<input type='search' class='input' name='fulltext[$i]' value='" . h($_GET["fulltext"][$i]) . "'>";
+				echo "<input type='search' class='input' name='fulltext[$i]' value='" . (isset($_GET["fulltext"]) ? h($_GET["fulltext"][$i]) : "") . "'>";
 				echo script("qsl('input').oninput = selectFieldChange;", "");
 				echo checkbox("boolean[$i]", 1, isset($_GET["boolean"][$i]), "BOOL");
 				echo "</div>\n";


### PR DESCRIPTION
With PHP set to show all errors (**_E_ALL_**), and when drilling down to a table that has **FULLTEXT** indexes, the following **_array offset on null_** error is displayed in the **Search** box just above the rows:

![adminerneo_fulltext](https://github.com/user-attachments/assets/9e87db8e-f4bf-4a23-9e86-420d7a3d8215)
When the form is first rendered (before entering a **FULLTEXT** search term) `$_GET["fulltext"]` does not yet exist. On subsequent page loads `$_GET["fulltext"]` is passed thus avoiding the error. This PR simply adds extra `isset()` logic to suppress the error on the initial page load when the form is first rendered.

@peterpp Please note: This PR is to the `new-default-theme` branch, however this same issue exists in the `version-5` branch (the old **V4** `main` branch does **_not_** have this issue). Thanks.