### PR TITLE
Fix PrettyJsonColumn plugin circular dependency

### DIFF
--- a/plugins/pretty-json-column.php
+++ b/plugins/pretty-json-column.php
@@ -3,13 +3,6 @@
 /** Pretty print JSON values in edit
 */
 class AdminerPrettyJsonColumn {
-	/** @var AdminerPlugin */
-	protected $adminer;
-
-	public function __construct($adminer) {
-		$this->adminer = $adminer;
-	}
-
 	private function _testJson($value) {
 		if ((substr($value, 0, 1) == '{' || substr($value, 0, 1) == '[') && ($json = json_decode($value, true))) {
 			return $json;
@@ -35,6 +28,6 @@ HTML;
 				$value = json_encode($json);
 			}
 		}
-		return $this->adminer->_callParent('processInput', array($field, $value, $function));
+		return adminer()->_callParent('processInput', array($field, $value, $function));
 	}
 }


### PR DESCRIPTION
The `pretty-json-column` plugin class needs an instance of `AdminerPlugin`, but the latter is cannot be passer to the constructor because it is instanciated afterwards.

Using the `adminer()` function solves this issue. 